### PR TITLE
add fastify port to env example and use in project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,16 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+# Fastfy port
+FASTIFY_PORT="3333"
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
+# Prisma database configuration
 DATABASE_URL="mysql://troopay:troopaypass@127.0.0.1:3306/troopay"
+
 # Generate jwt key
 JWT_KEY=""
-# api url to google api user info
+
+# Google api user info
 GOOGLE_PROFILE_URL="https://www.googleapis.com/oauth2/v2/userinfo"
-# SMTP Config (Mailcatcher recommended for development mode)
+
+# SMTP config
 SMTP_HOST="localhost"
 SMTP_PORT="1025"
 SMTP_IGNORE_TLS="true"

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,7 +75,7 @@ async function bootstrap() {
   await fastify.register(memberRoutes)
   await fastify.register(expenseRoutes)
 
-  await fastify.listen({ port: 3333, host: '0.0.0.0' })
+  await fastify.listen({ port: Number(process.env.FASTIFY_PORT) || 3333, host: '0.0.0.0' })
 }
 
 bootstrap()


### PR DESCRIPTION
Fiz pequenos ajustes para padronizar o .env, além de remover as informações padrão criadas pelo prisma. Em sua principal mudança fiz a inclusão de FASTIFY_PORT para alterar mais facilmente a porta padrão do projeto sem implicar em uma mudança mapeada pelo git.